### PR TITLE
Fix Logos support

### DIFF
--- a/GoToBible.Engine/ExtensionMethods.cs
+++ b/GoToBible.Engine/ExtensionMethods.cs
@@ -63,6 +63,16 @@ public static partial class ExtensionMethods
     }
 
     /// <summary>
+    /// Cleans a string for comparison.
+    /// </summary>
+    /// <param name="text">THe string to clean.</param>
+    /// <returns>The string suitable for comparison.</returns>
+    /// <remarks>
+    /// This is necessary as some punctuation characters are not recognised as such.
+    /// </remarks>
+    public static string Clean(this string text) => text.Replace('ʼ', '\'');
+
+    /// <summary>
     /// Counts the number of occurrences of a substirng within another string.
     /// </summary>
     /// <param name="text">The string to check within.</param>

--- a/GoToBible.Engine/Renderer.cs
+++ b/GoToBible.Engine/Renderer.cs
@@ -845,7 +845,7 @@ public partial class Renderer : IRenderer
                         word2 = words2[i];
                     }
 
-                    if (string.Compare(word1, word2, CultureInfo.InvariantCulture, parameters.AsCompareOptions()) == 0)
+                    if (string.Compare(word1.Clean(), word2.Clean(), CultureInfo.InvariantCulture, parameters.AsCompareOptions()) == 0)
                     {
                         // If we are in interlinear mode, return to non-interlinear mode
                         if (interlinear)
@@ -927,7 +927,7 @@ public partial class Renderer : IRenderer
                             {
                                 for (int l = i; l < words2.Count; l++)
                                 {
-                                    if (string.Compare(words1[k], words2[l], CultureInfo.InvariantCulture, parameters.AsCompareOptions()) == 0)
+                                    if (string.Compare(words1[k].Clean(), words2[l].Clean(), CultureInfo.InvariantCulture, parameters.AsCompareOptions()) == 0)
                                     {
                                         matches.Add(k, l);
                                         break;

--- a/GoToBible.Windows/ExtensionMethods.cs
+++ b/GoToBible.Windows/ExtensionMethods.cs
@@ -396,7 +396,7 @@ public static class ExtensionMethods
                     // Add the variant
                     bool variantFound = false;
                     string? key = variants.Keys.FirstOrDefault(k =>
-                        string.Compare(k, variant, CultureInfo.InvariantCulture, parameters.AsCompareOptions()) == 0);
+                        string.Compare(k.Clean(), variant.Clean(), CultureInfo.InvariantCulture, parameters.AsCompareOptions()) == 0);
                     if (key is not null)
                     {
                         variants[key] += $" {dataTable.Columns[i].ColumnName}";

--- a/GoToBible.Windows/FormApparatusGenerator.cs
+++ b/GoToBible.Windows/FormApparatusGenerator.cs
@@ -353,7 +353,7 @@ public partial class FormApparatusGenerator : Form
                         && (int)row["Chapter"] == (int)lastRow["Chapter"]
                         && (string)row["Verse"] == (string)lastRow["Verse"]
                         && (int)row["Occurrence"] == (int)lastRow["Occurrence"]
-                        && string.Compare((string)row["Phrase"], (string)lastRow["Phrase"], CultureInfo.InvariantCulture, apparatusParameters.AsCompareOptions()) == 0)
+                        && string.Compare(((string)row["Phrase"]).Clean(), ((string)lastRow["Phrase"]).Clean(), CultureInfo.InvariantCulture, apparatusParameters.AsCompareOptions()) == 0)
                     {
                         // Fill in the empty fields
                         for (int i = 5; i < row.ItemArray.Length - 1; i++)

--- a/GoToBible.Windows/WordComparer.cs
+++ b/GoToBible.Windows/WordComparer.cs
@@ -26,5 +26,5 @@ public class WordComparer : IComparer<string>
 
     /// <inheritdoc />
     public int Compare(string? x, string? y)
-        => string.Compare(x, y, CultureInfo.InvariantCulture, this.parameters.AsCompareOptions());
+        => string.Compare(x?.Clean(), y?.Clean(), CultureInfo.InvariantCulture, this.parameters.AsCompareOptions());
 }


### PR DESCRIPTION
Fixes bugs with the Logos Provider implementation including:
 * Non-standard punctuation not being recognized as punctuations i.e: ʼ
 * Sometimes extra verses appear at the start of a chapter (i.e. Romans 16 in RP2005)
 * Sometimes extra verses appear at the end of a chapter (i.e. Revelation 12 in RP2005)
 * Only the first verse displays for one chapter books (i.e. 2 John)