### PR TITLE
Package updates

### DIFF
--- a/GoToBible.Providers/GoToBible.Providers.csproj
+++ b/GoToBible.Providers/GoToBible.Providers.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.71" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
     <PackageReference Include="CsvHelper" Version="33.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />

--- a/GoToBible.Tests.Model/GoToBible.Tests.Model.csproj
+++ b/GoToBible.Tests.Model/GoToBible.Tests.Model.csproj
@@ -17,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GoToBible.Web/Client/GoToBible.Web.Client.csproj
+++ b/GoToBible.Web/Client/GoToBible.Web.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -23,8 +23,8 @@
 
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.10" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.15" PrivateAssets="all" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
   </ItemGroup>
 

--- a/GoToBible.Web/Server/GoToBible.Web.Server.csproj
+++ b/GoToBible.Web/Server/GoToBible.Web.Server.csproj
@@ -15,10 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="8.0.10" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.15" />
+    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="8.0.15" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
     <PackageReference Include="Pomelo.Extensions.Caching.MySql" Version="2.2.0" />
   </ItemGroup>
 

--- a/GoToBible.Windows/GoToBible.Windows.csproj
+++ b/GoToBible.Windows/GoToBible.Windows.csproj
@@ -47,9 +47,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="8.0.15" />
     <PackageReference Include="Microsoft.Web.WebView2">
-      <Version>1.0.2849.39</Version>
+      <Version>1.0.3240.44</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
* **Package Updates**: Updates HtmlAgilityPack in `GoToBible.Providers.csproj` from version 1.11.71 to 1.12.1.
* **Package Updates**: Updates Microsoft.NET.Test.Sdk, MSTest.TestAdapter, and MSTest.TestFramework in `GoToBible.Tests.Model.csproj` to newer versions (17.13.0, 3.8.3, and 3.8.3 respectively).
* **Package Updates**: Updates Microsoft.AspNetCore.Components.WebAssembly and Microsoft.AspNetCore.Components.WebAssembly.DevServer in `GoToBible.Web/Client/GoToBible.Web.Client.csproj` to version 8.0.15.
* **Package Updates**: Updates Microsoft.AspNetCore.Components.WebAssembly.Server, Microsoft.EntityFrameworkCore.SqlServer, and Microsoft.Extensions.Caching.SqlServer in `GoToBible.Web/Server/GoToBible.Web.Server.csproj` to version 8.0.15. Also updates Pomelo.EntityFrameworkCore.MySql from 8.0.2 to 8.0.3.
* **Package Updates**: Updates Microsoft.Extensions.Caching.SqlServer in `GoToBible.Windows/GoToBible.Windows.csproj` to version 8.0.15 and Microsoft.Web.WebView2 to version 1.0.3240.44.