### PR TITLE
Fix CodeQL issues

### DIFF
--- a/GoToBible.Engine/Renderer.cs
+++ b/GoToBible.Engine/Renderer.cs
@@ -865,23 +865,14 @@ public partial class Renderer : IRenderer
                 string verseNumber = line.GetVerseNumber();
                 if (verseNumber.IsValidVerseNumber())
                 {
-                    if (
-                        verseNumber.MatchesHighlightedVerses(
-                            parameters.PassageReference.HighlightedVerses
-                        )
+                    line = verseNumber.MatchesHighlightedVerses(
+                        parameters.PassageReference.HighlightedVerses
                     )
-                    {
-                        line =
-                            $"<sup id=\"{parameters.PassageReference.ChapterReference.ToString().EncodePassageForUrl()}_{verseNumber}\">{verseNumber}</sup>  <mark>"
-                            + line[(line.IndexOf(' ') + 1)..].Trim()
-                            + "</mark>";
-                    }
-                    else
-                    {
-                        line =
-                            $"<sup id=\"{parameters.PassageReference.ChapterReference.ToString().EncodePassageForUrl()}_{verseNumber}\">{verseNumber}</sup>  "
-                            + line[(line.IndexOf(' ') + 1)..].Trim();
-                    }
+                        ? $"<sup id=\"{parameters.PassageReference.ChapterReference.ToString().EncodePassageForUrl()}_{verseNumber}\">{verseNumber}</sup>  <mark>"
+                          + line[(line.IndexOf(' ') + 1)..].Trim()
+                          + "</mark>"
+                        : $"<sup id=\"{parameters.PassageReference.ChapterReference.ToString().EncodePassageForUrl()}_{verseNumber}\">{verseNumber}</sup>  "
+                          + line[(line.IndexOf(' ') + 1)..].Trim();
                 }
             }
             else if (int.TryParse(line, out int _))

--- a/GoToBible.Providers/LegacyStandardBible.cs
+++ b/GoToBible.Providers/LegacyStandardBible.cs
@@ -93,7 +93,7 @@ public partial class LegacyStandardBible(IOptions<LocalResourceOptions> options)
                 StringBuilder sb = new StringBuilder();
                 await foreach (
                     string line in File.ReadLinesAsync(
-                        Path.Combine(this.Options.Directory, zefaniaTranslation.Filename),
+                        Path.Join(this.Options.Directory, zefaniaTranslation.Filename),
                         cancellationToken
                     )
                 )

--- a/GoToBible.Providers/LocalResourceProvider.cs
+++ b/GoToBible.Providers/LocalResourceProvider.cs
@@ -43,7 +43,7 @@ public abstract class LocalResourceProvider : ApiProvider
         // Check the path
         this.isValidPath =
             Directory.Exists(this.Options.Directory)
-            && File.Exists(Path.Combine(this.Options.Directory, "index.csv"));
+            && File.Exists(Path.Join(this.Options.Directory, "index.csv"));
     }
 
     /// <inheritdoc/>
@@ -54,7 +54,7 @@ public abstract class LocalResourceProvider : ApiProvider
         if (this.isValidPath)
         {
             using StreamReader reader = new StreamReader(
-                Path.Combine(this.Options.Directory, "index.csv")
+                Path.Join(this.Options.Directory, "index.csv")
             );
             using CsvReader csvReader = new CsvReader(reader, CultureInfo.InvariantCulture);
             bool initialiseCache = this.Translations.Count == 0;

--- a/GoToBible.Providers/WebApiProvider.cs
+++ b/GoToBible.Providers/WebApiProvider.cs
@@ -191,7 +191,7 @@ public abstract class WebApiProvider : ApiProvider
     protected static TValue? DeserializeAnonymousType<TValue>(
         string json,
         TValue _,
-        JsonSerializerOptions? options = default
+        JsonSerializerOptions? options = null
     ) => JsonSerializer.Deserialize<TValue>(json, options);
 
     /// <summary>
@@ -215,7 +215,7 @@ public abstract class WebApiProvider : ApiProvider
     protected static TValue? Nullable<TValue>(TValue _) => default;
 
     /// <inheritdoc cref="IDisposable" />
-    protected virtual void Dispose(bool disposing)
+    protected void Dispose(bool disposing)
     {
         if (!this.disposedValue)
         {

--- a/GoToBible.Providers/Zefania.cs
+++ b/GoToBible.Providers/Zefania.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="Zefania.cs" company="Conglomo">
 // Copyright 2020-2024 Conglomo Limited. Please see LICENSE.md for license details.
 // </copyright>
@@ -8,6 +8,7 @@ namespace GoToBible.Providers;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;
@@ -261,18 +262,26 @@ public class Zefania(IOptions<LocalResourceOptions> options) : LocalResourceProv
 
                         // Clean up the file
                         string xmlFilePath = Path.Join(this.Options.Directory, xmlFilename);
-                        if (File.Exists(xmlFilePath))
+                        try
                         {
-                            File.Delete(xmlFilePath);
+                            if (File.Exists(xmlFilePath))
+                            {
+                                File.Delete(xmlFilePath);
+                            }
+                        }
+                        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or UnauthorizedAccessException)
+                        {
+                            // Log the exception or handle it appropriately
+                            Debug.WriteLine($"Error deleting file: {xmlFilePath}");
                         }
                     }
                 }
             }
-
-            // free unmanaged resources (unmanaged objects) and override finalizer
-            // set large fields to null
-            this.disposedValue = true;
         }
+
+        // free unmanaged resources (unmanaged objects) and override finalizer
+        // set large fields to null
+        this.disposedValue = true;
     }
 
     /// <summary>

--- a/GoToBible.Providers/Zefania.cs
+++ b/GoToBible.Providers/Zefania.cs
@@ -74,7 +74,7 @@ public class Zefania(IOptions<LocalResourceOptions> options) : LocalResourceProv
                 // Make sure the file is extracted, if it is a zip file
                 string fileName = this.ExtractFile(zefaniaTranslation.Filename);
                 XmlDocument xmlDocument = new XmlDocument();
-                xmlDocument.Load(Path.Combine(this.Options.Directory, fileName));
+                xmlDocument.Load(Path.Join(this.Options.Directory, fileName));
                 if (xmlDocument.DocumentElement?.HasChildNodes ?? false)
                 {
                     foreach (XmlNode bookNode in xmlDocument.DocumentElement.ChildNodes)
@@ -146,7 +146,7 @@ public class Zefania(IOptions<LocalResourceOptions> options) : LocalResourceProv
                 if (!string.IsNullOrWhiteSpace(book) && chapterNumber > 0)
                 {
                     XmlDocument xmlDocument = new XmlDocument();
-                    xmlDocument.Load(Path.Combine(this.Options.Directory, fileName));
+                    xmlDocument.Load(Path.Join(this.Options.Directory, fileName));
                     if (xmlDocument.DocumentElement?.HasChildNodes ?? false)
                     {
                         foreach (XmlNode bookNode in xmlDocument.DocumentElement.ChildNodes)
@@ -226,47 +226,44 @@ public class Zefania(IOptions<LocalResourceOptions> options) : LocalResourceProv
     }
 
     /// <inheritdoc cref="IDisposable" />
-    protected virtual void Dispose(bool disposing)
+    protected void Dispose(bool disposing)
     {
         if (!this.disposedValue)
         {
-            if (disposing)
+            if (disposing && this.Translations.Count > 0)
             {
                 // dispose managed state (managed objects)
 
                 // Make sure we have the translations cache set up
-                if (this.Translations.Count > 0)
+                foreach (LocalTranslation translation in this.Translations)
                 {
-                    foreach (LocalTranslation translation in this.Translations)
+                    // Make sure the translation file is is a zip file
+                    string fileExtension = Path.GetExtension(translation.Filename)
+                        .ToUpperInvariant();
+                    if (fileExtension == ".ZIP")
                     {
-                        // Make sure the translation file is is a zip file
-                        string fileExtension = Path.GetExtension(translation.Filename)
-                            .ToUpperInvariant();
-                        if (fileExtension == ".ZIP")
+                        // Check if a non-strongs version is in a strongs file
+                        string xmlFilename =
+                            Path.GetFileNameWithoutExtension(translation.Filename) + ".xml";
+                        if (
+                            translation.Filename.Contains(
+                                "_STRONG",
+                                StringComparison.OrdinalIgnoreCase
+                            ) && !File.Exists(Path.Join(this.Options.Directory, xmlFilename))
+                        )
                         {
-                            // Check if a non-strongs version is in a strongs file
-                            string xmlFilename =
-                                Path.GetFileNameWithoutExtension(translation.Filename) + ".xml";
-                            if (
-                                translation.Filename.Contains(
-                                    "_STRONG",
-                                    StringComparison.OrdinalIgnoreCase
-                                ) && !File.Exists(Path.Combine(this.Options.Directory, xmlFilename))
-                            )
-                            {
-                                xmlFilename = xmlFilename.Replace(
-                                    "_strong",
-                                    string.Empty,
-                                    StringComparison.OrdinalIgnoreCase
-                                );
-                            }
+                            xmlFilename = xmlFilename.Replace(
+                                "_strong",
+                                string.Empty,
+                                StringComparison.OrdinalIgnoreCase
+                            );
+                        }
 
-                            // Clean up the file
-                            string xmlFilePath = Path.Combine(this.Options.Directory, xmlFilename);
-                            if (File.Exists(xmlFilePath))
-                            {
-                                File.Delete(xmlFilePath);
-                            }
+                        // Clean up the file
+                        string xmlFilePath = Path.Join(this.Options.Directory, xmlFilename);
+                        if (File.Exists(xmlFilePath))
+                        {
+                            File.Delete(xmlFilePath);
                         }
                     }
                 }
@@ -291,12 +288,12 @@ public class Zefania(IOptions<LocalResourceOptions> options) : LocalResourceProv
         if (fileExtension == ".ZIP")
         {
             string xmlFilename = Path.GetFileNameWithoutExtension(fileName) + ".xml";
-            if (!File.Exists(Path.Combine(this.Options.Directory, xmlFilename)))
+            if (!File.Exists(Path.Join(this.Options.Directory, xmlFilename)))
             {
                 try
                 {
                     ZipFile.ExtractToDirectory(
-                        Path.Combine(this.Options.Directory, fileName),
+                        Path.Join(this.Options.Directory, fileName),
                         this.Options.Directory
                     );
                 }
@@ -309,7 +306,7 @@ public class Zefania(IOptions<LocalResourceOptions> options) : LocalResourceProv
             // Check if a non-strongs version is in a strongs file
             if (
                 fileName.Contains("_STRONG", StringComparison.OrdinalIgnoreCase)
-                && !File.Exists(Path.Combine(this.Options.Directory, xmlFilename))
+                && !File.Exists(Path.Join(this.Options.Directory, xmlFilename))
             )
             {
                 xmlFilename = xmlFilename.Replace(

--- a/GoToBible.Web/Server/Program.cs
+++ b/GoToBible.Web/Server/Program.cs
@@ -154,7 +154,7 @@ app.UseStaticFiles(
     {
         ServeUnknownFileTypes = true, // this was needed as IIS would not serve extension-less URLs from the directory without it
         FileProvider = new PhysicalFileProvider(
-            Path.Combine(Directory.GetCurrentDirectory(), "about")
+            Path.Join(Directory.GetCurrentDirectory(), "about")
         ),
         RequestPath = new PathString("/about"),
     }

--- a/GoToBible.Windows/FormMain.cs
+++ b/GoToBible.Windows/FormMain.cs
@@ -481,7 +481,7 @@ public sealed partial class FormMain : Form
         {
             CoreWebView2Environment environment = await CoreWebView2Environment.CreateAsync(
                 null,
-                Path.Combine(SettingsDirectory, "WebView2")
+                Path.Join(SettingsDirectory, "WebView2")
             );
             await webViewMain.EnsureCoreWebView2Async(environment);
             await webViewResource.EnsureCoreWebView2Async(environment);


### PR DESCRIPTION
Refactor code for improved maintainability:

- Use `Path.Join` for path concatenation.
- Simplify verse highlighting logic in the renderer for better readability.
- Remove `virtual` keyword from `Dispose` method in provider classes as it's not intended to be overridden.
- Address potential file cleanup issues in `Zefania` provider's `Dispose` method.